### PR TITLE
Fix white space on lower res

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,7 @@ body, html {
 #hero , #skills, #work, #contact {
   min-height: 100vh;
   position: relative;
-  padding: .001% 1em;
+  padding: 1px 1em;
   text-align: center;
   color: #f5f6f7;
   font-family: 'Roboto', Arial, sans-serif;


### PR DESCRIPTION
Apparently 0.001% was too small on smaller widths. Set it to 1 pixel since it's closest you'll get to 0 without issues.

Fixes #12 
